### PR TITLE
elan: init

### DIFF
--- a/cron/mon.sh
+++ b/cron/mon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @file mon.sh
 # @author Zizheng Guo
 # @brief Ultra simple synchronization monitor in bash

--- a/cron/sync_all.sh
+++ b/cron/sync_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /data/backend/cron/mon.sh
 

--- a/cron/sync_pypi.sh
+++ b/cron/sync_pypi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 judge=`ps aux|grep /usr/local/bin/bandersnatch|wc -l`
 

--- a/etc/elan-init.ps1
+++ b/etc/elan-init.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    .
+
+.DESCRIPTION
+    This is just a little script that can be downloaded from the Internet to
+    install elan. It just does platform detection, downloads the latest
+    installer, then runs it.
+
+.PARAMETER Verbose
+    Produce verbose output about the elan installation process.
+
+.PARAMETER NoPrompt
+    Do not present elan installation menu of choices.
+
+.PARAMETER NoModifyPath
+    Do not modify PATH environment variable.
+
+.PARAMETER DefaultToolchain
+    Which tool chain to setup as your default toolchain, or specify 'none'
+
+.PARAMETER ElanRoot
+    Where to find the elan-init tool, default is https://github.com/leanprover/elan/releases
+
+.PARAMETER ElanVersion
+    Specific version of elan to download and run instead of latest, e.g. 1.4.1
+#>
+
+# PKUOSC note: forked @ https://github.com/leanprover/elan/blob/af23a1ef506bd78a281d9d5678bd4d3426aead04/elan-init.sh
+
+param(
+    [bool] $Verbose = 0,
+    [bool] $NoPrompt = 0,
+    [bool] $NoModifyPath = 0,
+    [string] $DefaultToolchain = "",
+    [string] $ElanRoot = "https://mirrors.pku.edu.cn/elan/releases",
+    [string] $ElanVersion = ""
+)
+
+$cputype = [System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+
+if ($cputype -ne "AMD64") {
+    Write-Host "### Elan install only supports 64-bit Windows with AMD64 architecture"
+    return 1
+}
+
+$_arch = "x86_64-pc-windows-msvc"
+$_ext = ".exe"
+$temp = [System.IO.Path]::GetTempPath()
+$_dir = Join-Path $temp "elan"
+if (-not (Test-Path -Path $_dir)) {
+    $null = New-Item -ItemType Directory -Path $_dir
+}
+$_file = "$_dir/elan-init$_ext"
+
+Write-Host "info: downloading installer to ${temp}"
+
+try {
+    [string] $DownloadUrl = ""
+    if ($ElanVersion.Length -gt 0) {
+        $DownloadUrl = "$ElanRoot/download/v$ElanVersion/elan-$_arch.zip"
+    }
+    else {
+        $DownloadUrl = "$ElanRoot/latest/download/elan-$_arch.zip"
+    }
+    $null = Start-BitsTransfer -Source $DownloadUrl -Destination "$_dir/elan-init.zip" -ErrorAction Stop
+}
+catch {
+    Write-Host "Download failed for ${DownloadUrl}"
+    return 1
+}
+
+$null = Expand-Archive -Path "$_dir/elan-init.zip" -DestinationPath "$_dir" -Force
+
+$cmdline = " "
+if ($DefaultToolchain -ne "") {
+    $cmdline += "--default-toolchain $DefaultToolchain"
+}
+if ($NoPrompt) {
+    $cmdline += " -y"
+}
+if ($NoModifyPath) {
+    $cmdline += " --no-modify-path"
+}
+if ($Verbose) {
+    $cmdline += " --verbose"
+}
+$details = Start-Process -FilePath "$_file" -ArgumentList $cmdline -Wait -NoNewWindow -Passthru
+
+$rc = $details.exitCode
+if ($rc -ne 0 ) {
+    Write-Host "Elan failed with error code $rc"
+    return 1
+}
+
+$null = Remove-Item -Recurse -Force "$_dir"
+
+return 0

--- a/etc/elan-init.sh
+++ b/etc/elan-init.sh
@@ -1,0 +1,377 @@
+#!/bin/sh
+# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# This is just a little script that can be downloaded from the internet to
+# install elan. It just does platform detection, downloads the installer
+# and runs it.
+
+set -u
+
+ELAN_UPDATE_ROOT="https://github.com/leanprover/elan/releases"
+
+#XXX: If you change anything here, please make the same changes in setup_mode.rs
+usage() {
+    cat 1>&2 <<EOF
+elan-init 1.0.0 (408ed84 2017-02-11)
+The installer for elan
+
+USAGE:
+    elan-init [FLAGS] [OPTIONS]
+
+FLAGS:
+    -v, --verbose           Enable verbose output
+    -y                      Disable confirmation prompt.
+        --no-modify-path    Don't configure the PATH environment variable
+    -h, --help              Prints help information
+    -V, --version           Prints version information
+
+OPTIONS:
+        --default-toolchain <default-toolchain>    Choose a default toolchain to install
+        --default-toolchain none                   Do not install any toolchains
+EOF
+}
+
+main() {
+    need_cmd curl
+    need_cmd awk
+    need_cmd uname
+    need_cmd mktemp
+    need_cmd chmod
+    need_cmd mkdir
+    need_cmd rm
+    need_cmd rmdir
+
+    get_architecture || return 1
+    local _arch="$RETVAL"
+    assert_nz "$_arch" "arch"
+
+    local _ext=""
+    case "$_arch" in
+        *windows*)
+            _ext=".exe"
+            ;;
+    esac
+
+    local _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t elan)"
+    local _file="$_dir/elan-init$_ext"
+
+    local _ansi_escapes_are_valid=false
+    if [ -t 2 ]; then
+        if [ "${TERM+set}" = 'set' ]; then
+            case "$TERM" in
+                xterm*|rxvt*|urxvt*|linux*|vt*)
+                    _ansi_escapes_are_valid=true
+                ;;
+            esac
+        fi
+    fi
+
+    # check if we have to use /dev/tty to prompt the user
+    local need_tty=yes
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -y)
+                # user wants to skip the prompt -- we don't need /dev/tty
+                need_tty=no
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    if $_ansi_escapes_are_valid; then
+        printf "\33[1minfo:\33[0m downloading installer\n" 1>&2
+    else
+        printf '%s\n' 'info: downloading installer' 1>&2
+    fi
+
+    ensure mkdir -p "$_dir"
+    local _latest=$(ensure curl -sSfL -o /dev/null -w %{url_effective} "$ELAN_UPDATE_ROOT/latest" | cut -d'"' -f2 | awk -F/ '{print $NF}')
+
+    case "$_arch" in
+        *windows*)
+            ensure curl -sSfL "$ELAN_UPDATE_ROOT/download/$_latest/elan-$_arch.zip" > "$_dir/elan-init.zip"
+            (cd "$_dir"; ensure unzip elan-init.zip; ignore rm elan-init.zip)
+            ;;
+        *)
+            ensure curl -sSfL "$ELAN_UPDATE_ROOT/download/$_latest/elan-$_arch.tar.gz" > "$_dir/elan-init.tar.gz"
+            (cd "$_dir"; ensure tar xf elan-init.tar.gz; ignore rm elan-init.tar.gz)
+            ;;
+    esac
+
+    ensure chmod u+x "$_file"
+    if [ ! -x "$_file" ]; then
+        printf '%s\n' "Cannot execute $_file (likely because of mounting /tmp as noexec)." 1>&2
+        printf '%s\n' "Please copy the file to a location where you can execute binaries and run ./elan-init$_ext." 1>&2
+        exit 1
+    fi
+
+
+
+    if [ "$need_tty" = "yes" ]; then
+        # The installer is going to want to ask for confirmation by
+        # reading stdin.  This script was piped into `sh` though and
+        # doesn't have stdin to pass to its children. Instead we're going
+        # to explicitly connect /dev/tty to the installer's stdin.
+        if [ ! -t 1 ]; then
+            err "Unable to run interactively. Run with -y to accept defaults, --help for additional options"
+        fi
+
+        ignore "$_file" "$@" < /dev/tty
+    else
+        ignore "$_file" "$@"
+    fi
+
+    local _retval=$?
+
+    ignore rm "$_file"
+    ignore rmdir "$_dir"
+
+    return "$_retval"
+}
+
+get_bitness() {
+    need_cmd head
+    # Architecture detection without dependencies beyond coreutils.
+    # ELF files start out "\x7fELF", and the following byte is
+    #   0x01 for 32-bit and
+    #   0x02 for 64-bit.
+    # The printf builtin on some shells like dash only supports octal
+    # escape sequences, so we use those.
+    local _current_exe_head=$(head -c 5 /proc/self/exe )
+    if [ "$_current_exe_head" = "$(printf '\177ELF\001')" ]; then
+        echo 32
+    elif [ "$_current_exe_head" = "$(printf '\177ELF\002')" ]; then
+        echo 64
+    else
+        err "unknown platform bitness"
+    fi
+}
+
+get_endianness() {
+    local cputype=$1
+    local suffix_eb=$2
+    local suffix_el=$3
+
+    # detect endianness without od/hexdump, like get_bitness() does.
+    need_cmd head
+    need_cmd tail
+
+    local _current_exe_endianness="$(head -c 6 /proc/self/exe | tail -c 1)"
+    if [ "$_current_exe_endianness" = "$(printf '\001')" ]; then
+        echo "${cputype}${suffix_el}"
+    elif [ "$_current_exe_endianness" = "$(printf '\002')" ]; then
+        echo "${cputype}${suffix_eb}"
+    else
+        err "unknown platform endianness"
+    fi
+}
+
+get_architecture() {
+
+    local _ostype="$(uname -s)"
+    local _cputype="$(uname -m)"
+
+    if [ "$_ostype" = Linux ]; then
+        if [ "$(uname -o)" = Android ]; then
+            local _ostype=Android
+        fi
+    fi
+
+    if [ "$_ostype" = Darwin -a "$_cputype" = i386 ]; then
+        # Darwin `uname -s` lies
+        if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+            local _cputype=x86_64
+        fi
+    fi
+
+    case "$_ostype" in
+
+        Android)
+            local _ostype=linux-android
+            ;;
+
+        Linux)
+            local _ostype=unknown-linux-gnu
+            ;;
+
+        FreeBSD)
+            local _ostype=unknown-freebsd
+            ;;
+
+        NetBSD)
+            local _ostype=unknown-netbsd
+            ;;
+
+        DragonFly)
+            local _ostype=unknown-dragonfly
+            ;;
+
+        Darwin)
+            local _ostype=apple-darwin
+            ;;
+
+        MINGW* | MSYS* | CYGWIN*)
+            local _ostype=pc-windows-msvc
+            ;;
+
+        *)
+            err "unrecognized OS type: $_ostype"
+            ;;
+
+    esac
+
+    case "$_cputype" in
+
+        i386 | i486 | i686 | i786 | x86)
+            local _cputype=i686
+            ;;
+
+        xscale | arm)
+            local _cputype=arm
+            if [ "$_ostype" = "linux-android" ]; then
+                local _ostype=linux-androideabi
+            fi
+            ;;
+
+        armv6l)
+            local _cputype=arm
+            if [ "$_ostype" = "linux-android" ]; then
+                local _ostype=linux-androideabi
+            else
+                local _ostype="${_ostype}eabihf"
+            fi
+            ;;
+
+        armv7l | armv8l)
+            local _cputype=armv7
+            if [ "$_ostype" = "linux-android" ]; then
+                local _ostype=linux-androideabi
+            else
+                local _ostype="${_ostype}eabihf"
+            fi
+            ;;
+
+        arm64 | aarch64)
+            local _cputype=aarch64
+            ;;
+
+        x86_64 | x86-64 | x64 | amd64)
+            local _cputype=x86_64
+            ;;
+
+        mips)
+            local _cputype="$(get_endianness $_cputype "" 'el')"
+            ;;
+
+        mips64)
+            local _bitness="$(get_bitness)"
+            if [ $_bitness = "32" ]; then
+                if [ $_ostype = "unknown-linux-gnu" ]; then
+                    # 64-bit kernel with 32-bit userland
+                    # endianness suffix is appended later
+                    local _cputype=mips
+                fi
+            else
+                # only n64 ABI is supported for now
+                local _ostype="${_ostype}abi64"
+            fi
+
+            local _cputype="$(get_endianness $_cputype "" 'el')"
+            ;;
+
+        ppc)
+            local _cputype=powerpc
+            ;;
+
+        ppc64)
+            local _cputype=powerpc64
+            ;;
+
+        ppc64le)
+            local _cputype=powerpc64le
+            ;;
+
+        *)
+            err "unknown CPU type: $_cputype"
+
+    esac
+
+    # Detect 64-bit linux with 32-bit userland
+    if [ $_ostype = unknown-linux-gnu -a $_cputype = x86_64 ]; then
+        if [ "$(get_bitness)" = "32" ]; then
+            local _cputype=i686
+        fi
+    fi
+
+    # Detect armv7 but without the CPU features Lean needs in that build,
+    # and fall back to arm.
+    # See https://github.com/rust-lang-nursery/rustup.rs/issues/587.
+    if [ $_ostype = "unknown-linux-gnueabihf" -a $_cputype = armv7 ]; then
+        if ensure grep '^Features' /proc/cpuinfo | grep -q -v neon; then
+            # At least one processor does not have NEON.
+            local _cputype=arm
+        fi
+    fi
+
+    local _arch="$_cputype-$_ostype"
+
+    RETVAL="$_arch"
+}
+
+say() {
+    echo "elan: $1"
+}
+
+err() {
+    say "$1" >&2
+    exit 1
+}
+
+need_cmd() {
+    if ! check_cmd "$1"
+    then err "need '$1' (command not found)"
+    fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+    return $?
+}
+
+need_ok() {
+    if [ $? != 0 ]; then err "$1"; fi
+}
+
+assert_nz() {
+    if [ -z "$1" ]; then err "assert_nz $2"; fi
+}
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing
+# command.
+ensure() {
+    "$@"
+    need_ok "command failed: $*"
+}
+
+# This is just for indicating that commands' results are being
+# intentionally ignored. Usually, because it's being executed
+# as part of error handling.
+ignore() {
+    "$@"
+}
+
+main "$@" || exit 1

--- a/etc/elan-init.sh
+++ b/etc/elan-init.sh
@@ -13,9 +13,11 @@
 # install elan. It just does platform detection, downloads the installer
 # and runs it.
 
+# PKUOSC note: forked @ https://github.com/leanprover/elan/blob/04475bbb556a1144b446f44aae30dadd8ba160d3/elan-init.sh
+
 set -u
 
-ELAN_UPDATE_ROOT="https://github.com/leanprover/elan/releases"
+ELAN_UPDATE_ROOT="https://mirrors.pku.edu.cn/elan/releases"
 
 #XXX: If you change anything here, please make the same changes in setup_mode.rs
 usage() {

--- a/rsyncd/run.sh
+++ b/rsyncd/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 files=`ls /data/repos`
 cf='/etc/rsyncd.conf'

--- a/scripts/copy_repos.py
+++ b/scripts/copy_repos.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 S=/data/repos
 D=/datahdd/repos
 

--- a/scripts/sync_all.py
+++ b/scripts/sync_all.py
@@ -6,10 +6,10 @@ def get_sync_script(up_urls, file_out, local_dir, log_dir):
             out = up_url[0]
         elif len(up_url)==2:
             url, dir_name = up_url
-            out = "rsync -avHh --delete --delete-after --delay-updates --safe-links --stats --no-o --no-g {} {}/{} > {}/{}.`date +%Y-%m-%d-%H-%M-%S`.log 2>&1 ".format(url, local_dir,  dir_name, log_dir, dir_name)
+            out = "rsync -avHh --delete --delete-after --delay-updates --safe-links --stats --no-o --no-g {} {}/{} > {}/{}.`date +%Y-%m-%d-%H-%M-%S`.log 2>&1 ".format(url, local_dir, dir_name, log_dir, dir_name)
         elif len(up_url)==3:
             url, dir_name, exl = up_url
-            out =  "rsync -avHh --delete --delete-after --delay-updates --safe-links --exclude={}  --stats --no-o --no-g {} {}/{} > {}/{}.`date +%Y-%m-%d-%H-%M-%S`.log 2>&1 ".format(exl, url, local_dir,  dir_name, log_dir, dir_name)
+            out = "rsync -avHh --delete --delete-after --delay-updates --safe-links --exclude={}  --stats --no-o --no-g {} {}/{} > {}/{}.`date +%Y-%m-%d-%H-%M-%S`.log 2>&1 ".format(exl, url, local_dir, dir_name, log_dir, dir_name)
         print(out)
         # print()
         f.write(out+"\n")

--- a/scripts/sync_elan.sh
+++ b/scripts/sync_elan.sh
@@ -8,7 +8,10 @@ declare -a all_stores=(\
 all_stores_len=${#all_stores[@]}
 
 for (( i=0; i<${all_stores_len}; i++ )); do
-  mkdir -p ${all_stores[$i]}
+  mkdir -p ${all_stores[$i]}/releases
+  mkdir -p ${all_stores[$i]}/installers
+  cp ./etc/elan-init.sh  ${all_stores[$i]}/installers/elan-init.sh
+  cp ./etc/elan-init.ps1 ${all_stores[$i]}/installers/elan-init.ps1
 done
 
 latest_release=$(curl -sSfL https://api.github.com/repos/leanprover/elan/releases/latest)
@@ -24,7 +27,7 @@ for asset in $latest_assets; do
   curl -sSfL "$url" -o "$temp_file"
 
   for (( j=0; j<${all_stores_len}; j++ )); do
-    store=${all_stores[$j]}
+    store=${all_stores[$j]}/releases
     cp "$temp_file" "$store/$asset"
   done
 

--- a/scripts/sync_elan.sh
+++ b/scripts/sync_elan.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+declare -a all_stores=(\
+  "/data/repos/elan/releases"    \
+  "/datahdd/repos/elan/releases" \
+)
+all_stores_len=${#all_stores[@]}
+
+for (( i=0; i<${all_stores_len}; i++ )); do
+  mkdir -p ${all_stores[$i]}
+done
+
+latest_release=$(curl -sSfL https://api.github.com/repos/leanprover/elan/releases/latest)
+latest_assets=$(echo "$latest_release" | jq -r '.assets[] | select(.name | endswith(".tar.gz") or endswith(".zip")) | .name')
+latest_name=$(echo "$latest_release" | jq -r '.name')
+
+base_url="https://github.com/leanprover/elan/releases/download/$latest_name"
+
+for asset in $latest_assets; do
+  url="$base_url/$asset"
+
+  temp_file=$(mktemp)
+  curl -sSfL "$url" -o "$temp_file"
+
+  for (( j=0; j<${all_stores_len}; j++ )); do
+    store=${all_stores[$j]}
+    cp "$temp_file" "$store/$asset"
+  done
+
+  rm "$temp_file"
+done


### PR DESCRIPTION
This PR tries to add the `elan` package manager of Lean4 to the PKU mirror.

Some TODOs

- Does the data stores in the correct place?
- Can the sync script access the `./etc` dir which is added to the repo in this PR?
- How to add this scripts to `./cron`?
- better logging and messages
- How can I test the newly add sync scripts?

I hope those above TODOs can be solved and this PR can work as an intro to a series incoming PRs, including Lean4 toolchains, Lean4 pkgs source, Lean4 pkg cache and Lean4 pkg webdocs.
